### PR TITLE
implement strictly typed terminateCircularRelationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mizdra/graphql-codegen-typescript-mock-data",
-    "version": "3.5.0",
+    "version": "3.6.0-alpha.0",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mizdra/graphql-codegen-typescript-mock-data",
-    "version": "3.6.0-alpha.1",
+    "version": "3.6.0-alpha.2",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
-    "name": "graphql-codegen-typescript-mock-data",
+    "name": "@mizdra/graphql-codegen-typescript-mock-data",
     "version": "3.5.0",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",
     "typings": "dist/esnext/index.d.ts",
     "repository": "ardeois/graphql-codegen-typescript-mock-data",
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    },
     "author": {
         "name": "Corentin Ardeois",
         "email": "corentin.ardeois@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mizdra/graphql-codegen-typescript-mock-data",
-    "version": "3.6.0-alpha.0",
+    "version": "3.6.0-alpha.1",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,7 +424,7 @@ export const ${toMockName(
             typeName,
             casedName,
             prefix,
-        )} = <const T extends DeepPartial<${casedNameWithPrefix}> = {}>(overrides?: Partial<${casedNameWithPrefix}>, _relationshipsToOmit: Set<string> = new Set()): Merge<TerminateCircularRelationship<DeepExcludeMaybe<${typenameReturnType}${casedNameWithPrefix}>>, Required<T>> => {
+        )} = <const T extends DeepPartial<${casedNameWithPrefix}> = {}>(overrides?: T, _relationshipsToOmit: Set<string> = new Set()): Merge<TerminateCircularRelationship<DeepExcludeMaybe<${typenameReturnType}${casedNameWithPrefix}>>, Required<T>> => {
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('${casedName}');
     return {${typename}


### PR DESCRIPTION
demo: https://github.com/mizdra/playground-graphql-codegen-typescript-mock-data

npm: https://www.npmjs.com/package/@mizdra/graphql-codegen-typescript-mock-data